### PR TITLE
aufs: fix compile warning

### DIFF
--- a/fs/aufs/vdir.c
+++ b/fs/aufs/vdir.c
@@ -829,7 +829,7 @@ static int seek_vdir(struct file *file, struct dir_context *ctx)
 
 out:
 	/* smp_mb(); */
-	AuTraceErr(!valid);
+	AuTraceErr(valid - 1);
 	return valid;
 }
 


### PR DESCRIPTION
fs/aufs/debug.h:95:19: warning: comparison of constant '0'
with boolean expression is always false [-Wbool-compare]
   if (unlikely((e) < 0)) \
                    ^

fs/aufs/vdir.c:852:2: note: in expansion of macro 'AuTraceErr'
   AuTraceErr(!valid);
   ^~~~~~~~~~

In expansion of AuTraceErr(!valid), comparison of (!valid)
and constant '0' always passes unlikely(x) false. function
'static int seek_vdir(struct file *file, struct dir_context *ctx)'
is to find whether there is a valid vd_deblk following ctx->pos.
return 1 means valid, 0 for not. Change to AuTraceErr(valid - 1)
makes more sense.

Signed-off-by: Kexin(Casey) Chen <Casey.Chen@windriver.com>
Signed-off-by: Dengke Du <dengke.du@windriver.com>